### PR TITLE
Use required services instead of optional | add more to reduce the entry barrier

### DIFF
--- a/src/main/resources/archetype-resources/plugin/plugin.xml
+++ b/src/main/resources/archetype-resources/plugin/plugin.xml
@@ -27,15 +27,12 @@
         <providedService interface="${package}.I${serviceName}"/>
       </provides>
       <prerequisites>
-        <optionalService
-          interface="com.ibm.team.repository.common.service.IContributorService">
-        </optionalService>
-        <optionalService
-          interface="com.ibm.team.workitem.service.IWorkItemServer">
-        </optionalService>
-        <optionalService
-          interface="com.ibm.team.repository.common.internal.IContributorRestService">
-        </optionalService>
+        <requiredService interface="com.ibm.team.process.service.IProcessServerService"/>
+        <requiredService interface="com.ibm.team.repository.common.service.IContributorService"/>
+        <requiredService interface="com.ibm.team.repository.service.IRepositoryItemService" />
+        <requiredService interface="com.ibm.team.workitem.service.IAuditableServer"/>
+        <requiredService interface="com.ibm.team.workitem.service.IQueryServer" />
+        <requiredService interface="com.ibm.team.workitem.service.IWorkItemServer"/>
       </prerequisites>
     </serviceProvider>
   </extension>


### PR DESCRIPTION
The current solution works fine, but users will soon need more services, so I vote for adding the most important one right now, as the experience learned me that these six services are the most important one.

In addition, I switched to mark them required as they are:

- available anyhow when using jazz
- using the services doesn't make sense if they are not available 