### PR TITLE
Require Bundle javax.mail

### DIFF
--- a/src/main/resources/archetype-resources/plugin/META-INF/MANIFEST.MF
+++ b/src/main/resources/archetype-resources/plugin/META-INF/MANIFEST.MF
@@ -14,6 +14,7 @@ Require-Bundle:
  com.hp.hpl.jena,
  javax.xml.stream,
  javax.xml,
+ javax.mail, 
  org.apache.log4j,
  com.ibm.icu,
  org.apache.commons.codec,


### PR DESCRIPTION
When working with Emails in a plugin, a `MessagingException`must be caught. Include the bundle that contains this exception by default.

```java

    IMailerService mailerService = getService(IMailerService.class);
    MailSender sender = mailerService.getDefaultSender();
    if (mailerService.isMailEnabled()) {
      try {
        for (String mailAddress : mailAddresses) {
          mailerService.sendMail(sender, mailAddress, "subject", "body", null);
        }
      } catch (MessagingException e) {
        throw new TeamRepositoryException(e.getMessage());
      }

```